### PR TITLE
fix(actions): invalid payload type since refactoring

### DIFF
--- a/.github/workflows/aws_lambda.publish.yaml
+++ b/.github/workflows/aws_lambda.publish.yaml
@@ -14,13 +14,14 @@ jobs:
         with:
           go-version: 1.17.x
       - name: Build new release of github-quick-actions
-        run: |
-          go build -tags aws_lambda -o github-quick-actions \
-            -ldflags '-X github.com/prometheus/common/version.Version='"${GITHUB_REF##*/}" \
-            -ldflags '-X github.com/prometheus/common/version.Revision=${{ github.sha }}' \
-            -ldflags '-X github.com/prometheus/common/version.Branch=main' \
-            -ldflags '-X github.com/prometheus/common/version.BuildUser=${{ github.actor }}@github.${{ github.run_id }}' \
-            -ldflags '-X github.com/prometheus/common/version.BuildDate='"$(date --iso-8601=seconds)"
+        run: >-
+          go build -tags aws_lambda -o github-quick-actions -ldflags "
+          -X github.com/prometheus/common/version.Version=${GITHUB_REF##*/}
+          -X github.com/prometheus/common/version.Revision=${{ github.sha }}
+          -X github.com/prometheus/common/version.Branch=${{ github.head_ref }}
+          -X github.com/prometheus/common/version.BuildUser=${{ github.actor }}@github.${{ github.run_id }}
+          -X github.com/prometheus/common/version.BuildDate=$(date --iso-8601=seconds)
+          "
       - name: Archive code coverage results
         uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074 # renovate: tag=v2.2.4
         with:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -27,13 +27,14 @@ jobs:
         with:
           go-version: 1.17.x
       - name: Build github-quick-actions for ${{ matrix.platform }}
-        run: |
-          go build -tags ${{ matrix.platform }} -o github-quick-actions \
-            -ldflags '-X github.com/prometheus/common/version.Version='"${GITHUB_REF##*/}" \
-            -ldflags '-X github.com/prometheus/common/version.Revision=${{ github.sha }}' \
-            -ldflags '-X github.com/prometheus/common/version.Branch=${{ github.head_ref }}' \
-            -ldflags '-X github.com/prometheus/common/version.BuildUser=${{ github.actor }}@github.${{ github.run_id }}' \
-            -ldflags '-X github.com/prometheus/common/version.BuildDate='"$(date --iso-8601=seconds)"
+        run: >-
+          go build -tags ${{ matrix.platform }} -o github-quick-actions -ldflags "
+          -X github.com/prometheus/common/version.Version=${GITHUB_REF##*/}
+          -X github.com/prometheus/common/version.Revision=${{ github.sha }}
+          -X github.com/prometheus/common/version.Branch=${{ github.head_ref }}
+          -X github.com/prometheus/common/version.BuildUser=${{ github.actor }}@github.${{ github.run_id }}
+          -X github.com/prometheus/common/version.BuildDate=$(date --iso-8601=seconds)
+          "
 
   test:
     name: Go test & coverage

--- a/.github/workflows/security.codeql.yaml
+++ b/.github/workflows/security.codeql.yaml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      issues: write
+      pull-requests: write
       security-events: write
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # renovate: tag=v2.3.4
@@ -29,7 +29,7 @@ jobs:
         uses: actions/github-script@f891eff65186019cbb3f7190c4590bc0a1b76fbc # renovate: tag=v4.1.0
         with:
           script: |
-            github.issues.deleteLabel({
+            github.issues.removeLabel({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,

--- a/internal/quick-actions/assign_e2e_test.go
+++ b/internal/quick-actions/assign_e2e_test.go
@@ -1,0 +1,46 @@
+package quick_actions_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	quick_actions "xnku.be/github-quick-actions/internal/quick-actions"
+	quick_action "xnku.be/github-quick-actions/pkg/gh-quick-action"
+	"xnku.be/github-quick-actions/pkg/gh-quick-action/fixtures"
+)
+
+func TestAssignE2E(t *testing.T) {
+	comments := []string{
+		"/assign me",
+		"/assign @mojombo",
+		"/assign me @mojombo",
+		`/assign me\n/assign @mojombo`,
+	}
+
+	cc := &fixtures.MockClientCreator{}
+	cc.On("NewInstallationClient", mock.Anything).Return(fixtures.MockGithubClient, nil)
+	cc.On("github.Request", mock.Anything).Return(&http.Response{StatusCode: http.StatusCreated}, nil)
+	cc.On("github.RequestValidation", mock.Anything).Return(func(*http.Request) {})
+
+	ghApp := quick_action.NewGithubQuickActions(cc)
+	ghApp.AddQuickAction("assign", quick_actions.AssignIssueComment)
+
+	payloadTpl, _ := template.New("").Parse(fixtures.IssueCommentEventJSON)
+	for _, comment := range comments {
+		t.Run(comment, func(t *testing.T) {
+			buffer := &bytes.Buffer{}
+			err := payloadTpl.Execute(buffer, map[string]interface{}{"body": comment})
+			require.NoError(t, err)
+
+			err = ghApp.Handle(context.TODO(), quick_actions.AssignIssueComment.OnEvent.Name(), "", buffer.Bytes())
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/internal/quick-actions/unassign_e2e_test.go
+++ b/internal/quick-actions/unassign_e2e_test.go
@@ -1,0 +1,46 @@
+package quick_actions_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	quick_actions "xnku.be/github-quick-actions/internal/quick-actions"
+	quick_action "xnku.be/github-quick-actions/pkg/gh-quick-action"
+	"xnku.be/github-quick-actions/pkg/gh-quick-action/fixtures"
+)
+
+func TestUnassignE2E(t *testing.T) {
+	comments := []string{
+		"/unassign me",
+		"/unassign @mojombo",
+		"/unassign me @mojombo",
+		`/unassign me\n/assign @mojombo`,
+	}
+
+	cc := &fixtures.MockClientCreator{}
+	cc.On("NewInstallationClient", mock.Anything).Return(fixtures.MockGithubClient, nil)
+	cc.On("github.Request", mock.Anything).Return(&http.Response{StatusCode: http.StatusCreated}, nil)
+	cc.On("github.RequestValidation", mock.Anything).Return(func(*http.Request) {})
+
+	ghApp := quick_action.NewGithubQuickActions(cc)
+	ghApp.AddQuickAction("unassign", quick_actions.UnassignIssueComment)
+
+	payloadTpl, _ := template.New("").Parse(fixtures.IssueCommentEventJSON)
+	for _, comment := range comments {
+		t.Run(comment, func(t *testing.T) {
+			buffer := &bytes.Buffer{}
+			err := payloadTpl.Execute(buffer, map[string]interface{}{"body": comment})
+			require.NoError(t, err)
+
+			err = ghApp.Handle(context.TODO(), quick_actions.UnassignIssueComment.OnEvent.Name(), "", buffer.Bytes())
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/pkg/gh-quick-action/event_wrappers.go
+++ b/pkg/gh-quick-action/event_wrappers.go
@@ -12,13 +12,13 @@ var GithubIssueCommentEvent = genericEventDefinition{
 	wraps: func(payload []byte) (githubWrappedEvent, error) {
 		var event github.IssueCommentEvent
 		err := json.Unmarshal(payload, &event)
-		return &GithubWrappedIssueCommentEvent{event}, err
+		return &GithubWrappedIssueCommentEvent{&event}, err
 	},
 }
 
 // GithubWrappedIssueCommentEvent wraps github.IssueCommentEvent structure
 type GithubWrappedIssueCommentEvent struct {
-	github.IssueCommentEvent
+	*github.IssueCommentEvent
 }
 
 func (g GithubWrappedIssueCommentEvent) GetEventPayload() githubEventPayload {
@@ -28,19 +28,19 @@ func (g GithubWrappedIssueCommentEvent) GetBody() string {
 	return g.IssueCommentEvent.GetComment().GetBody()
 }
 
-// GithubIssuesEvent defines Github issue comment event.
+// GithubIssuesEvent defines Github issue event.
 var GithubIssuesEvent = genericEventDefinition{
 	name: "issues",
 	wraps: func(payload []byte) (githubWrappedEvent, error) {
 		var event github.IssuesEvent
 		err := json.Unmarshal(payload, &event)
-		return &GithubWrappedIssueEvent{event}, err
+		return &GithubWrappedIssueEvent{&event}, err
 	},
 }
 
 // GithubWrappedIssueEvent wraps github.IssuesEvent structure
 type GithubWrappedIssueEvent struct {
-	github.IssuesEvent
+	*github.IssuesEvent
 }
 
 func (g GithubWrappedIssueEvent) GetEventPayload() githubEventPayload {

--- a/pkg/gh-quick-action/fixtures/fixtures_event.go
+++ b/pkg/gh-quick-action/fixtures/fixtures_event.go
@@ -9,14 +9,14 @@ import (
 )
 
 const (
-	issueCommentEventJSON = `{"action":"created","issue":{"number":1},"comment":{"user":{"login":"xunleii"},"body":"{{ .body }}"},"repository":{"name":"github-quick-actions","full_name":"xunleii/github-quick-actions","owner":{"login":"xunleii"}},"installation":{"id":1234567890}}`
+	IssueCommentEventJSON = `{"action":"created","issue":{"number":1},"comment":{"user":{"login":"xunleii"},"body":"{{ .body }}"},"repository":{"name":"github-quick-actions","full_name":"xunleii/github-quick-actions","owner":{"login":"xunleii"}},"installation":{"id":1234567890}}`
 )
 
 var (
 	// IssueCommentEventType manages handler using IssueComment events
 	IssueCommentEventType EventGenerator = func(cc *MockClientCreator, fixture EventFixture) quick_action.GithubQuickActionEvent {
 		var issueCommentEvent github.IssueCommentEvent
-		_ = json.Unmarshal([]byte(issueCommentEventJSON), &issueCommentEvent)
+		_ = json.Unmarshal([]byte(IssueCommentEventJSON), &issueCommentEvent)
 
 		return quick_action.GithubQuickActionEvent{
 			Payload:   &issueCommentEvent,


### PR DESCRIPTION
```
{
    "level": "error",
    "version": "",
    "github_event_type": "issue_comment",
    "github_delivery_id": "ff3d75a0-1bf8-11ec-9976-c3ebaf008dea",
    "github_repository_name": "github-quick-actions",
    "github_repository_owner": "xunleii",
    "error": "invalid event type; only accept *github.IssueCommentEvent but get quick_action.GithubQuickActionEvent",
    "time": 1632351679,
    "message": "failed to run 'assign': invalid event type; only accept *github.IssueCommentEvent but get quick_action.GithubQuickActionEvent"
}
```